### PR TITLE
  Corregir altura del contenedor de lista de videos   

### DIFF
--- a/src/app/domains/video/presentation/video-shell/video-shell.component.html
+++ b/src/app/domains/video/presentation/video-shell/video-shell.component.html
@@ -1,17 +1,20 @@
-<div class="selector-category" value="movies">
-  <ion-segment (ionChange)="segmentChanged($event)">
-    <ion-segment-button value="movies">
-      <ion-label>Movies</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="tvshows">
-      <ion-label>TV Shows</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="actors">
-      <ion-label>Actors</ion-label>
-    </ion-segment-button>
-    <ion-segment-button value="genres">
-      <ion-label>Genres</ion-label>
-    </ion-segment-button>
-  </ion-segment>
-  <router-outlet></router-outlet>
-</div>
+<ion-segment (ionChange)="segmentChanged($event)">
+  <ion-segment-button value="movies">
+    <ion-label>Movies</ion-label>
+  </ion-segment-button>
+  <ion-segment-button value="tvshows">
+    <ion-label>TV Shows</ion-label>
+  </ion-segment-button>
+  <ion-segment-button value="actors">
+    <ion-label>Actors</ion-label>
+  </ion-segment-button>
+  <ion-segment-button value="genres">
+    <ion-label>Genres</ion-label>
+  </ion-segment-button>
+</ion-segment>
+<ion-content class="ion-padding">
+  <div class="selector-category" value="movies"></div>
+  <div>
+    <ion-router-outlet></ion-router-outlet>
+  </div>
+</ion-content>

--- a/src/app/domains/video/presentation/video-shell/video-shell.component.ts
+++ b/src/app/domains/video/presentation/video-shell/video-shell.component.ts
@@ -1,12 +1,12 @@
 import { Component, inject } from '@angular/core';
-import { Router, RouterOutlet } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
+import { Router } from '@angular/router';
+import { IonSegment, IonSegmentButton, IonLabel, IonContent, IonRouterOutlet } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-video-shell',
   templateUrl: './video-shell.component.html',
   styleUrls: ['./video-shell.component.scss'],
-  imports: [IonicModule, RouterOutlet],
+  imports: [IonSegment, IonSegmentButton, IonLabel, IonContent, IonRouterOutlet],
 })
 export class VideoShellComponent {
   private readonly router = inject(Router);


### PR DESCRIPTION
                                                                                                                                                                               
  ## Summary                                                                                                                                                                                     
  - Corregir la altura mínima del contenedor de videos que no permitía visualizar tiles completos
  - Migrar video-shell a imports standalone de Ionic

  ## Problema
  El contenedor que alberga la lista de videos tenía una altura insuficiente que recortaba los tiles de video, afectando la experiencia de usuario.

  ## Solución
  - Agregar `<ion-content>` al video-shell (igual que music-shell)
  - Reemplazar `IonicModule` por imports standalone: `IonSegment`, `IonSegmentButton`, `IonLabel`, `IonContent`
  - Usar `IonRouterOutlet` en lugar de `RouterOutlet`

  ## Test plan
  - [x] Navegar a la sección de videos
  - [x] Verificar que los tiles de movies se muestran completos
  - [x] Verificar que los tiles de tvshows se muestran completos
  - [x] Verificar que los tiles de actors se muestran completos
  - [x] Verificar que los tiles de genres se muestran completos
  - [x] Verificar scroll funciona correctamente