### PR TITLE
Activar navegación por hashes para evitar errores al recargar

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
-import { provideRouter, RouteReuseStrategy, withPreloading, PreloadAllModules } from '@angular/router';
+import { provideRouter, RouteReuseStrategy, withPreloading, PreloadAllModules, withHashLocation } from '@angular/router';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
 
@@ -19,7 +19,7 @@ import { REMOTE_PROVIDERS } from '@domains/remote';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
-    provideRouter(routes, withPreloading(PreloadAllModules)),
+    provideRouter(routes, withPreloading(PreloadAllModules), withHashLocation()),
     provideIonicAngular(),
     provideHttpClient(withInterceptorsFromDi()),
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },


### PR DESCRIPTION
## Summary
  - Activar `HashLocationStrategy` mediante `withHashLocation()` en el router de Angular
  - Las URLs pasan de `/music/albums` a `/#/music/albums`
  - Evita errores 404 al recargar la página, ya que el servidor de Kodi no reescribe URLs

  ## Test plan
  - [x] Navegar entre secciones y verificar que las URLs usan el formato `/#/...`
  - [x] Recargar la página en cualquier ruta y confirmar que no da 404
  - [x] Verificar que los enlaces y navegación programática siguen funcionando