### PR TITLE
Título de página dinámico con la media en reproducción

### DIFF
--- a/src/app/layout/app-shell.component.ts
+++ b/src/app/layout/app-shell.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal, effect } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { Router, NavigationEnd } from '@angular/router';
 import { IonRouterOutlet, IonHeader, IonIcon, IonToolbar, IonMenu, IonButton, IonButtons, IonSearchbar, IonContent, IonMenuToggle } from '@ionic/angular/standalone';
 import { Subject } from 'rxjs';
@@ -32,11 +33,22 @@ import { GlobalSearchService } from '@shared/services/global-search.service';
 })
 export class AppShellComponent implements OnInit, OnDestroy {
   private readonly router = inject(Router);
+  private readonly titleService = inject(Title);
   private readonly destroy$ = new Subject<void>();
   readonly playBackFacade = inject(PlaybackFacade);
   readonly globalSearch = inject(GlobalSearchService);
 
   readonly isRemoteActive = signal(false);
+
+  private readonly titleEffect = effect(() => {
+    const track = this.playBackFacade.playerInfo();
+    if (track?.title) {
+      const artist = track.artist?.length ? ` - ${track.artist.join(', ')}` : '';
+      this.titleService.setTitle(`${track.title}${artist}`);
+    } else {
+      this.titleService.setTitle('Kodi Ready');
+    }
+  });
 
   ngOnInit(): void {
     this.playBackFacade.connect();


### PR DESCRIPTION
## Summary                                                                                                                                                                                     
  - El título del navegador ahora muestra dinámicamente el nombre del track y artista en reproducción (ej: `Bohemian Rhapsody - Queen`)                                                          
  - Cuando no hay nada reproduciéndose, el título muestra `Kodi Ready`
  - Usa un `effect()` reactivo sobre `playerInfo()` del WebSocket en `AppShellComponent`, sin suscripciones manuales

  ## Test plan
  - [x] Reproducir una canción → verificar que el título del navegador muestra `Título - Artista`
  - [x] Detener la reproducción → verificar que el título cambia a `Kodi Ready`
  - [x] Cambiar de canción → verificar que el título se actualiza automáticamente
  - [x] `ng build` compila sin errores