### PR TITLE
Mover timebar sobre los controles del player         

### DIFF
--- a/src/app/domains/music/player/presentation/components/player-control/player-control.component.html
+++ b/src/app/domains/music/player/presentation/components/player-control/player-control.component.html
@@ -1,4 +1,28 @@
 <div class="player-control">
+  <!-- Seekbar: [0:00][════════][3:45] -->
+  <div class="player-control__seekbar">
+    <span class="player-control__time">
+      @if (showHours) {
+        {{ currentHours }}:
+      }
+      {{ currentMinutes | zeroPadding }}:{{ currentSeconds | zeroPadding }}
+    </span>
+
+    <ion-range
+      class="player-control__range"
+      [value]="seekDisplayPercentage"
+      (ionKnobMoveStart)="onSeekStart()"
+      (ionKnobMoveEnd)="onSeekEnd($event)"
+    />
+
+    <span class="player-control__time">
+      @if (showHours) {
+        {{ totalHours }}:
+      }
+      {{ totalMinutes | zeroPadding }}:{{ totalSeconds | zeroPadding }}
+    </span>
+  </div>
+
   <!-- Transport: [🔀][⏮][⏯][⏭][🔁] -->
   <div class="player-control__transport">
     <ion-button
@@ -35,29 +59,5 @@
     >
       <ion-icon slot="icon-only" [name]="getRepeatIcon()" />
     </ion-button>
-  </div>
-
-  <!-- Seekbar: [0:00][════════][3:45] -->
-  <div class="player-control__seekbar">
-    <span class="player-control__time">
-      @if (showHours) {
-        {{ currentHours }}:
-      }
-      {{ currentMinutes | zeroPadding }}:{{ currentSeconds | zeroPadding }}
-    </span>
-
-    <ion-range
-      class="player-control__range"
-      [value]="seekDisplayPercentage"
-      (ionKnobMoveStart)="onSeekStart()"
-      (ionKnobMoveEnd)="onSeekEnd($event)"
-    />
-
-    <span class="player-control__time">
-      @if (showHours) {
-        {{ totalHours }}:
-      }
-      {{ totalMinutes | zeroPadding }}:{{ totalSeconds | zeroPadding }}
-    </span>
   </div>
 </div>


### PR DESCRIPTION
## Summary
  - La seekbar (barra de tiempo) se mueve de debajo a encima de los controles de transporte (play, pause, next, etc.)
  - Mejora la visibilidad y accesibilidad de la información de tiempo durante la reproducción

  ## Test plan
  - [x] Verificar que la barra de tiempo aparece sobre los botones de transporte
  - [x] Verificar que el seek (arrastrar el knob) sigue funcionando correctamente
  - [x] Verificar que los tiempos actualizados se muestran bien
  - [x] `ng build` compila sin errores