### PR TITLE
 Mejorar diseño del fondo con album art blur en control-nav y remote

### DIFF
--- a/src/app/domains/remote/presentation/components/remote-control/remote-control.component.html
+++ b/src/app/domains/remote/presentation/components/remote-control/remote-control.component.html
@@ -1,3 +1,7 @@
+<div class="page-bg"
+     [style.background-image]="backgroundImage ? 'url(' + backgroundImage + ')' : 'none'"></div>
+<div class="page-bg-overlay"></div>
+
 <div
   class="remote-control"
   [style.background-image]="backgroundImage ? 'url(' + backgroundImage + ')' : 'none'"

--- a/src/app/domains/remote/presentation/components/remote-control/remote-control.component.scss
+++ b/src/app/domains/remote/presentation/components/remote-control/remote-control.component.scss
@@ -1,6 +1,28 @@
 :host {
   display: block;
   width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+// Blurred album art page background
+.page-bg {
+  position: absolute;
+  inset: -20px;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  filter: blur(20px);
+  z-index: 0;
+}
+
+// Dark overlay for page background
+.page-bg-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 0;
 }
 
 .remote-control {
@@ -18,6 +40,7 @@
   border-radius: 24px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   position: relative;
+  z-index: 1;
   overflow: hidden;
 
   // Overlay oscuro para legibilidad sobre el fanart

--- a/src/app/layout/app-shell.component.html
+++ b/src/app/layout/app-shell.component.html
@@ -62,6 +62,9 @@
 
     @if (!isRemoteActive()) {
     <div class="control-nav">
+      <div class="control-nav__bg"
+           [style.background-image]="controlBgUrl() ? 'url(' + controlBgUrl() + ')' : 'none'"></div>
+      <div class="control-nav__overlay"></div>
       <!-- Sección 1: Track Info -->
       <div class="control-nav__info">
         <player-current-track

--- a/src/app/layout/app-shell.component.scss
+++ b/src/app/layout/app-shell.component.scss
@@ -11,7 +11,7 @@ ion-searchbar {
 }
 
 .control-nav {
-    background-color: rgba(0, 0, 0, .75);
+    background-color: #000;
     position: fixed;
     bottom: 0;
     left: 0;
@@ -24,6 +24,31 @@ ion-searchbar {
     z-index: 100;
     padding: 12px 32px;
     gap: 48px;
+    overflow: hidden;
+
+    // Blurred album art background
+    &__bg {
+        position: absolute;
+        inset: -20px;
+        background-size: cover;
+        background-position: center;
+        filter: blur(20px);
+        z-index: 0;
+    }
+
+    // Dark overlay for legibility
+    &__overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        z-index: 0;
+    }
+
+    // All children above the overlay
+    &__info, &__playback, &__extras {
+        position: relative;
+        z-index: 1;
+    }
 
     // Sección 1: Track Info
     &__info {

--- a/src/app/layout/app-shell.component.ts
+++ b/src/app/layout/app-shell.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal, effect } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal, effect, computed } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, NavigationEnd } from '@angular/router';
 import { IonRouterOutlet, IonHeader, IonIcon, IonToolbar, IonMenu, IonButton, IonButtons, IonSearchbar, IonContent, IonMenuToggle } from '@ionic/angular/standalone';
@@ -8,6 +8,7 @@ import { CurrentPlayListComponent } from '@domains/music/playlist';
 import { CurrentTrackComponent, PlayerControlComponent, SoundComponent } from '@domains/music/player';
 import { PlaybackFacade } from '@domains/music/playback/application/playback.facade';
 import { GlobalSearchService } from '@shared/services/global-search.service';
+import { AssetsPipe } from '@shared/pipes/assets.pipe';
 
 @Component({
   selector: 'app-shell',
@@ -39,6 +40,15 @@ export class AppShellComponent implements OnInit, OnDestroy {
   readonly globalSearch = inject(GlobalSearchService);
 
   readonly isRemoteActive = signal(false);
+
+  private readonly assetsPipe = new AssetsPipe();
+
+  readonly controlBgUrl = computed(() => {
+    const track = this.playBackFacade.playerInfo();
+    const src = track?.fanart || track?.thumbnail || '';
+    if (!src) return '';
+    return this.assetsPipe.transform(src);
+  });
 
   private readonly titleEffect = effect(() => {
     const track = this.playBackFacade.playerInfo();


### PR DESCRIPTION
 ## Summary
  - Se agrega fondo blur con la imagen del album/fanart del track actual al control-nav (barra inferior de controles)
  - Se aplica el mismo efecto como fondo de página en la vista remote-control
  - Fallback a fondo negro sólido cuando no hay track reproduciéndose
  - Se reutiliza el patrón existente de `AssetsPipe` y `backgroundImage` del componente remote-control

  ## Test plan
  - [x] Reproducir un track y verificar que el control-nav muestra el album art con blur
  - [x] Verificar que texto y botones son legibles sobre el fondo
  - [x] Cambiar de track y confirmar que la imagen se actualiza
  - [x] Sin track reproduciéndose: fondo negro sólido (fallback)
  - [x] Verificar la vista remote: fondo de página con blur detrás de la tarjeta de control
  - [x] Probar en layout mobile (responsive)