### PR TITLE
fix(scroll): add max-height utility classes for scroll containers

### DIFF
--- a/src/app/domains/music/album/presentation/components/album-detail/album-detail.component.html
+++ b/src/app/domains/music/album/presentation/components/album-detail/album-detail.component.html
@@ -1,4 +1,4 @@
-<ion-content class="album-detail">
+<ion-content class="album-detail scroll-detail">
   <div class="album-detail__frame">
     <div class="album-detail__cover">
       <ion-img

--- a/src/app/domains/music/album/presentation/components/album-list/album-list.component.html
+++ b/src/app/domains/music/album/presentation/components/album-list/album-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="album-list">
+<ion-content class="album-list scroll-list">
   <ion-list class="album-list__grid">
     @for (album of albums(); track album.albumId) {
       <app-media-tile

--- a/src/app/domains/music/artist/presentation/components/artist-detail/artist-detail.component.html
+++ b/src/app/domains/music/artist/presentation/components/artist-detail/artist-detail.component.html
@@ -1,4 +1,4 @@
-<ion-content>
+<ion-content class="scroll-detail">
   @if (artist(); as artist) {
     <div class="artist-frame">
       <div class="artist-info">

--- a/src/app/domains/music/artist/presentation/components/artist-list/artist-list.component.html
+++ b/src/app/domains/music/artist/presentation/components/artist-list/artist-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="flex-tile-list">
+<ion-content class="flex-tile-list scroll-list">
   <ion-list>
     @for (artist of artists(); track artist.artistId) {
       <ion-card

--- a/src/app/domains/music/genre/presentation/components/genre-detail/genre-detail.component.html
+++ b/src/app/domains/music/genre/presentation/components/genre-detail/genre-detail.component.html
@@ -1,7 +1,6 @@
 @if (isLoading()) {
   <ion-progress-bar type="indeterminate" />
 }
-
 <ion-header>
   <ion-toolbar>
     <ion-buttons slot="start">
@@ -10,8 +9,7 @@
     <ion-title>{{ genre()?.label }}</ion-title>
   </ion-toolbar>
 </ion-header>
-
-<ion-content class="genre-detail-content">
+<ion-content class="genre-detail-content scroll-list">
   <!-- Albums Section -->
   @if (albums().length > 0) {
     <ion-list-header>

--- a/src/app/domains/video/actor/presentation/components/actor-list/actor-list.component.html
+++ b/src/app/domains/video/actor/presentation/components/actor-list/actor-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="actor-list">
+<ion-content class="actor-list scroll-list">
   <ion-list class="actor-list__grid">
     @for (actor of actors(); track actor.name) {
       <app-media-tile

--- a/src/app/domains/video/genre/presentation/components/video-genre-list/video-genre-list.component.html
+++ b/src/app/domains/video/genre/presentation/components/video-genre-list/video-genre-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="genre-list">
+<ion-content class="genre-list scroll-list">
   <ion-list class="genre-list__grid">
     @for (genre of genres(); track genre.genreId) {
       <app-media-tile

--- a/src/app/domains/video/movie/presentation/components/movie-list/movie-list.component.html
+++ b/src/app/domains/video/movie/presentation/components/movie-list/movie-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="movie-list">
+<ion-content class="movie-list scroll-list">
   <ion-list class="movie-list__grid">
     @for (movie of movies(); track movie.movieId) {
       <app-media-tile

--- a/src/app/domains/video/tvshow/presentation/components/tvshow-list/tvshow-list.component.html
+++ b/src/app/domains/video/tvshow/presentation/components/tvshow-list/tvshow-list.component.html
@@ -2,7 +2,7 @@
   <ion-progress-bar type="indeterminate" />
 }
 
-<ion-content class="tvshow-list">
+<ion-content class="tvshow-list scroll-list">
   <ion-list class="tvshow-list__grid">
     @for (tvshow of tvshows(); track tvshow.tvshowId) {
       <app-media-tile

--- a/src/scss/_objects.scss
+++ b/src/scss/_objects.scss
@@ -2,3 +2,11 @@
 // OBJECTS – Layout patterns (no cosmetics)
 // ==========================================================================
 // Add reusable layout objects here (containers, grids, media object, …).
+
+.scroll-list {
+  max-height: calc(100% - 90px);
+}
+
+.scroll-detail {
+  max-height: calc(100% - 63px);
+}


### PR DESCRIPTION
Tiles were cut off at the bottom of list and detail views because ion-content had no constrained height. Introduces two shared SCSS utility classes and applies them across all list/detail components.

- scroll-list: calc(100% - 90px)
- scroll-detail: calc(100% - 63px)

Closes #169